### PR TITLE
Add pytest tests for utility functions

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,110 @@
+import io
+import gzip
+from pathlib import Path
+import sys
+import os
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import utils
+
+
+# Helper to create a small WARC file for testing
+from warcio.warcwriter import WARCWriter
+from warcio.statusandheaders import StatusAndHeaders
+
+def _create_warc(path: Path):
+    with path.open("wb") as fh:
+        gz = gzip.GzipFile(fileobj=fh, mode="wb")
+        writer = WARCWriter(gz, gzip=False)
+        headers = StatusAndHeaders("200 OK", [("Content-Type", "text/plain")])
+        record = writer.create_warc_record(
+            "http://example.com/test.py", "response", payload=io.BytesIO(b"print(1)"), http_headers=headers
+        )
+        writer.write_record(record)
+        gz.close()
+
+
+def test_extension_from_url_present():
+    ext_func = getattr(utils, "extension_from_url", None)
+    if ext_func is None:
+        pytest.skip("extension_from_url not implemented")
+    assert ext_func("https://example.com/code.py") == ".py"
+    assert ext_func("https://example.com/path/file.tar.gz") in {".tar.gz", ".gz"}
+    assert ext_func("https://example.com/a/b/?q=1") == ""
+
+
+def test_save_file_collision(tmp_path):
+    url = "http://example.com/hello.py"
+    first = utils.save_file(b"one", url, str(tmp_path))
+    second = utils.save_file(b"two", url, str(tmp_path))
+    assert Path(first).name == "hello.py"
+    assert Path(second).name == "hello_1.py"
+    assert (tmp_path / "hello.py").read_bytes() == b"one"
+    assert (tmp_path / "hello_1.py").read_bytes() == b"two"
+
+
+def test_list_warc_keys():
+    pages = [
+        {"Contents": [{"Key": "a.warc.gz"}, {"Key": "b.txt"}]},
+        {"Contents": [{"Key": "c.warc.gz"}]},
+    ]
+
+    class Paginator:
+        def paginate(self, Bucket, Prefix):
+            assert Bucket == "bucket"
+            assert Prefix == "prefix"
+            for p in pages:
+                yield p
+
+    class Client:
+        def get_paginator(self, name):
+            assert name == "list_objects_v2"
+            return Paginator()
+
+    result = utils.list_warc_keys(Client(), "bucket", "prefix", 2)
+    assert result == ["a.warc.gz", "c.warc.gz"]
+
+
+def test_stream_and_extract(tmp_path, monkeypatch):
+    warc_path = tmp_path / "sample.warc.gz"
+    _create_warc(warc_path)
+
+    class FakeClient:
+        def generate_presigned_url(self, op, Params, ExpiresIn):
+            return "http://example.com/presigned"
+
+    class DummyResp:
+        def __init__(self, path):
+            self.raw = open(path, "rb")
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.raw.close()
+
+    def fake_get(url, stream=True, headers=None):
+        assert url == "http://example.com/presigned"
+        return DummyResp(warc_path)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    records = list(
+        utils.stream_and_extract(
+            FakeClient(),
+            "bucket",
+            "key",
+            [".py"],
+            rate_limit=0,
+            user_agent="ua",
+        )
+    )
+    assert len(records) == 1
+    assert records[0][0] == "http://example.com/test.py"
+    assert records[0][1] == b"print(1)"


### PR DESCRIPTION
## Summary
- add pytest suite covering utils helpers
- include fixtures and mocks for list_warc_keys and stream_and_extract
- skip extension_from_url test if function is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847be233a448322a72c72e8411d5f69