### PR TITLE
Add flake8 config to align with Black defaults

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203, W503, W391


### PR DESCRIPTION
## Summary
- add `.flake8` config to ignore some rules and set a line length of 88

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c51149f08322baed318d35b38a53