### PR TITLE
Add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone. We pledge to act and
+interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness to others
+- Being respectful of differing opinions and experiences
+- Gracefully accepting constructive feedback
+
+Examples of unacceptable behavior include:
+
+- Trolling, insulting or derogatory comments
+- Personal or political attacks
+- Harassment in public or private
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable
+behavior and will take appropriate corrective action in response to any
+behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Reporting
+
+Instances of abusive behavior can be reported privately to the maintainers at
+<email@example.com>. All complaints will be reviewed and investigated and will
+result in a response that is appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,39 @@
 # Contributing
 
-Thank you for considering contributing to CC Codex Crawler!
+Thank you for considering contributing to **CC Codex Crawler**! Contributions of all kinds are appreciated.
 
-1. Fork the repository and create a feature branch.
-2. Install dependencies and the `pre-commit` tool:
+## Issue Templates
+
+When opening an issue on GitHub, please select the appropriate template (bug report or feature request) and include as much relevant information as possible. Clear steps to reproduce and expected behaviour help us resolve issues faster.
+
+## Pull Request Process
+
+1. Fork the repository and create a descriptive feature branch.
+2. Install dependencies and set up `pre-commit` hooks:
    ```bash
    pip install -r requirements.txt
    pip install pre-commit
    pre-commit install
    ```
-3. Run the test suite:
+3. Run the test suite locally:
    ```bash
    pytest -q
    ```
-4. Open a pull request with a clear description of your changes.
+4. Commit your changes following the coding style below and open a pull request against `main`. Provide a clear description of the motivation and link related issues when possible.
+5. Pull requests are automatically checked with `pre-commit` and `pytest` in CI. Ensure both pass before requesting review.
 
-All code should pass `pre-commit` and `pytest` before submission.
+## Coding Style
+
+The codebase follows [PEP 8](https://peps.python.org/pep-0008/) guidelines and uses the following tools via `pre-commit`:
+
+- [Black](https://github.com/psf/black) for formatting
+- [isort](https://github.com/pycqa/isort) for import order
+- [Flake8](https://github.com/pycqa/flake8) for linting
+
+Run the following command before submitting your pull request to automatically format and lint your changes:
+
+```bash
+pre-commit run --all-files
+```
+
+All code must pass `pre-commit` and the test suite before it can be merged.


### PR DESCRIPTION
## Summary
- enhance `CONTRIBUTING.md` with issue template info, PR process, and coding style
- add `CODE_OF_CONDUCT.md` describing community behavior

## Testing
- `pre-commit run --files CONTRIBUTING.md CODE_OF_CONDUCT.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ee0ed0e883228b4aadb59b0a0910