### PR TITLE
Add HTTP fallback for crawling without AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ crawler.py --> utils.py --> OUTPUT_DIR
    ```bash
    export OPENAI_API_KEY=<your key>
    ```
-3. Start crawling Common Crawl:
+3. Start crawling Common Crawl (AWS credentials required):
    ```bash
    python crawler.py --warcs 5 --samples 100
+   ```
+4. Or run in HTTP mode without credentials:
+   ```bash
+   python crawler.py --mode http --warcs 5 --samples 100
    ```
 
 ## CLI Examples
@@ -37,6 +41,10 @@ crawler.py --> utils.py --> OUTPUT_DIR
 * Override target extensions:
   ```bash
   TARGET_EXTENSIONS=.py,.js python crawler.py
+  ```
+* Run without AWS credentials:
+  ```bash
+  python crawler.py --mode http --warcs 20
   ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- allow crawling without AWS credentials using HTTPS
- support `--mode` argument in `crawler.py`
- implement HTTP helpers in `utils.py`
- document HTTP usage in README
- add tests for new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ac3c61848322b75f2335bd68391a