### PR TITLE
Update prefix handling for HTTP functions

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,7 +140,7 @@ def test_list_warc_keys_http(tmp_path, monkeypatch):
     monkeypatch.setattr("requests.get", fake_get)
 
     keys = utils.list_warc_keys_http("crawl-data/CC-MAIN-2020-50", 1)
-    assert keys == ["a.warc.gz"]
+    assert keys == ["crawl-data/a.warc.gz"]
 
 
 def test_stream_and_extract_http(tmp_path, monkeypatch):
@@ -162,14 +162,17 @@ def test_stream_and_extract_http(tmp_path, monkeypatch):
             self.raw.close()
 
     def fake_get(url, stream=True, headers=None):
-        assert url.endswith("sample.warc.gz")
+        assert (
+            url
+            == "https://data.commoncrawl.org/crawl-data/dir/sample.warc.gz"
+        )
         return DummyResp(warc_path)
 
     monkeypatch.setattr("requests.get", fake_get)
 
     records = list(
         utils.stream_and_extract_http(
-            "dir/sample.warc.gz",
+            "crawl-data/dir/sample.warc.gz",
             [".py"],
             rate_limit=0,
             user_agent="ua",

--- a/utils.py
+++ b/utils.py
@@ -370,7 +370,7 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
         for line in gz:
             key = line.decode("utf-8").strip()
             if key.endswith(".warc.gz"):
-                keys.append(key)
+                keys.append(f"crawl-data/{key}")
                 if len(keys) >= max_keys:
                     break
     return keys


### PR DESCRIPTION
## Summary
- include `crawl-data/` prefix when listing WARC files via HTTPS
- ensure HTTP streaming uses that prefixed key
- adjust tests for the new key format and complete URL checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b97e7ef4832299d6dba44b465daa