### PR TITLE
Add configurable timeout for HTTP streaming

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,8 +98,9 @@ def test_stream_and_extract(tmp_path, monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             self.raw.close()
 
-    def fake_get(url, stream=True, headers=None):
+    def fake_get(url, stream=True, headers=None, timeout=None):
         assert url == "http://example.com/presigned"
+        assert timeout == utils.REQUEST_TIMEOUT
         return DummyResp(warc_path)
 
     monkeypatch.setattr("requests.get", fake_get)
@@ -172,9 +173,10 @@ def test_stream_and_extract_http(tmp_path, monkeypatch):
 
     calls = []
 
-    def fake_get(url, stream=True, headers=None):
+    def fake_get(url, stream=True, headers=None, timeout=None):
         calls.append(1)
         assert url == "https://data.commoncrawl.org/crawl-data/dir/sample.warc.gz"
+        assert timeout == utils.REQUEST_TIMEOUT
         if len(calls) == 1:
             raise requests.RequestException("fail")
         return DummyResp(warc_path)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,13 @@
 
 from typing import Dict, List, Set
 
+import os
+
+# Timeout in seconds for all network requests performed by this module. The
+# value can be overridden by setting the ``REQUEST_TIMEOUT`` environment
+# variable.
+REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", 30))
+
 
 def extension_from_url(url: str) -> str:
     """Return the file extension from ``url`` if present.
@@ -241,7 +248,9 @@ def stream_and_extract(
             )
 
             headers = {"User-Agent": user_agent}
-            with requests.get(url, stream=True, headers=headers) as resp:
+            with requests.get(
+                url, stream=True, headers=headers, timeout=REQUEST_TIMEOUT
+            ) as resp:
                 resp.raise_for_status()
 
                 with gzip.GzipFile(fileobj=resp.raw) as gz:
@@ -414,7 +423,9 @@ def stream_and_extract_http(
     while attempt < 3:
         try:
             headers = {"User-Agent": user_agent}
-            with requests.get(url, stream=True, headers=headers) as resp:
+            with requests.get(
+                url, stream=True, headers=headers, timeout=REQUEST_TIMEOUT
+            ) as resp:
                 resp.raise_for_status()
                 with gzip.GzipFile(fileobj=resp.raw) as gz:
                     for record in ArchiveIterator(gz):


### PR DESCRIPTION
## Summary
- add `REQUEST_TIMEOUT` constant controlled via env var
- use timeout in `stream_and_extract` and `stream_and_extract_http`
- update tests to check the new timeout parameter

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e21201b48322ae7f1d5883698420