### PR TITLE
Improve HTTP crawl prefix guidance and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ crawler.py --> utils.py --> OUTPUT_DIR
    ```bash
    python crawler.py --warcs 5 --samples 100
    ```
-4. Or run in HTTP mode without AWS credentials. You can set
-   `CRAWL_PREFIX` to target a specific crawl:
+4. Or run in HTTP mode without AWS credentials. **Set** `CRAWL_PREFIX` to a
+   specific crawl (for example `crawl-data/CC-MAIN-2024-22`); otherwise the
+   crawler attempts `CC-MAIN-LATEST`, which may not exist:
    ```bash
    CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 python crawler.py --mode http --warcs 5 --samples 100
    ```
@@ -48,11 +49,8 @@ crawler.py --> utils.py --> OUTPUT_DIR
   ```bash
   python crawler.py --warcs 20
   ```
-* Run without AWS credentials:
-  ```bash
-  python crawler.py --mode http --warcs 20
-  ```
-* Specify a different crawl in HTTP mode:
+* Run without AWS credentials (HTTP mode). Always set `CRAWL_PREFIX` to a
+  specific crawl:
   ```bash
   CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 python crawler.py --mode http --warcs 20
   ```

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -153,6 +153,24 @@ def test_list_warc_keys_http(tmp_path, monkeypatch):
     assert keys == ["crawl-data/a.warc.gz"]
 
 
+def test_list_warc_keys_http_latest_404(monkeypatch):
+    class Resp:
+        def __init__(self):
+            self.status_code = 404
+            self.content = b""
+
+        def raise_for_status(self):
+            raise requests.HTTPError(response=self)
+
+    def fake_get(url, timeout=10):
+        return Resp()
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    with pytest.raises(RuntimeError):
+        utils.list_warc_keys_http("crawl-data", 1)
+
+
 def test_stream_and_extract_http(tmp_path, monkeypatch):
     warc_path = tmp_path / "sample.warc.gz"
     _create_warc(warc_path)

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,7 @@
 """Utility functions for the CC Codex crawler."""
 
-from typing import Dict, List, Set
-
 import os
+from typing import Dict, List, Set
 
 # Timeout in seconds for all network requests performed by this module. The
 # value can be overridden by setting the ``REQUEST_TIMEOUT`` environment
@@ -369,8 +368,10 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
 
     base_url = "https://data.commoncrawl.org"
     norm = prefix.strip("/")
+    appended_latest = False
     if "CC-MAIN" not in norm:
         norm = f"{norm}/CC-MAIN-LATEST"
+        appended_latest = True
     url = f"{base_url}/{norm}/warc.paths.gz"
 
     attempt = 0
@@ -379,6 +380,11 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
     while attempt < 3:
         try:
             resp = requests.get(url, timeout=10)
+            if resp.status_code == 404 and appended_latest:
+                raise RuntimeError(
+                    "CC-MAIN-LATEST not found. Set CRAWL_PREFIX to a specific crawl, "
+                    "e.g., 'crawl-data/CC-MAIN-2024-22'."
+                )
             resp.raise_for_status()
 
             keys: List[str] = []


### PR DESCRIPTION
## Summary
- document explicit `CRAWL_PREFIX` usage for HTTP mode
- detect 404 errors for `CC-MAIN-LATEST` and instruct user to set `CRAWL_PREFIX`
- test new 404 handling behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e356906c832288740ca0d1ec2061