### PR TITLE
Refine HTTP crawl listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ crawler.py --> utils.py --> OUTPUT_DIR
    python crawler.py --warcs 5 --samples 100
    ```
 4. Or run in HTTP mode without AWS credentials. **Set** `CRAWL_PREFIX` to a
-   specific crawl (for example `crawl-data/CC-MAIN-2024-22`); otherwise the
-   crawler attempts `CC-MAIN-LATEST`, which may not exist:
+   specific crawl (for example `crawl-data/CC-MAIN-2024-22`):
    ```bash
    CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 python crawler.py --mode http --warcs 5 --samples 100
    ```

--- a/crawler.py
+++ b/crawler.py
@@ -106,14 +106,16 @@ def main() -> None:
 
     try:
         if use_http:
-            warc_keys = list_warc_keys_http(CRAWL_PREFIX, args.warcs)
+            prefix = os.getenv("CRAWL_PREFIX", CRAWL_PREFIX).strip("/")
+            warc_keys = list_warc_keys_http(prefix, args.warcs)
         else:
             warc_keys = list_warc_keys(s3_client, S3_BUCKET, CRAWL_PREFIX, args.warcs)
     except Exception as exc:  # pragma: no cover - network failure
         if not use_http:
             logger.warning("Falling back to HTTP listing due to: %s", exc)
             try:
-                warc_keys = list_warc_keys_http(CRAWL_PREFIX, args.warcs)
+                prefix = os.getenv("CRAWL_PREFIX", CRAWL_PREFIX).strip("/")
+                warc_keys = list_warc_keys_http(prefix, args.warcs)
                 use_http = True
             except Exception as exc2:
                 logger.warning("Failed to list WARC files: %s", exc2)

--- a/utils.py
+++ b/utils.py
@@ -368,11 +368,14 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
 
     base_url = "https://data.commoncrawl.org"
     norm = prefix.strip("/")
-    appended_latest = False
-    if "CC-MAIN" not in norm:
-        norm = f"{norm}/CC-MAIN-LATEST"
-        appended_latest = True
-    url = f"{base_url}/{norm}/warc.paths.gz"
+
+    # Ensure we only prepend "crawl-data/" once
+    if not norm.startswith("crawl-data/"):
+        prefix_path = f"crawl-data/{norm}"
+    else:
+        prefix_path = norm
+
+    url = f"{base_url}/{prefix_path}/warc.paths.gz"
 
     attempt = 0
     backoff = 1.0
@@ -380,10 +383,10 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
     while attempt < 3:
         try:
             resp = requests.get(url, timeout=10)
-            if resp.status_code == 404 and appended_latest:
+            if resp.status_code == 404:
                 raise RuntimeError(
-                    "CC-MAIN-LATEST not found. Set CRAWL_PREFIX to a specific crawl, "
-                    "e.g., 'crawl-data/CC-MAIN-2024-22'."
+                    f"HTTP listing not found for prefix '{prefix_path}'. "
+                    f"Use a valid CRAWL_PREFIX, e.g., 'crawl-data/CC-MAIN-2025-21'."
                 )
             resp.raise_for_status()
 


### PR DESCRIPTION
## Summary
- handle `CRAWL_PREFIX` env var when listing over HTTP
- improve `list_warc_keys_http` URL building and error message
- document updated HTTP usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e825fbb08322a8f4912629fbb328