### PR TITLE
Improve doc cross links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Typical log output looks like:
 2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
 ```
 
-See [docs/USAGE.md](docs/USAGE.md) for more details and additional examples.
+## Documentation
+
+This README covers installation and quick-start examples. See
+[docs/USAGE.md](docs/USAGE.md) for extended usage instructions and additional
+examples.
 
 ## Contributing
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,8 @@
 # Usage Guide
 
-This document expands on the information in the project README and demonstrates
-how to configure the crawler for different file types.
+This document expands on the information in the project
+[README](../README.md) and demonstrates how to configure the crawler for
+different file types.
 
 ## Downloading MP3 Samples
 


### PR DESCRIPTION
## Summary
- clarify pointer to extended usage docs in README
- mention main README from the usage guide

## Testing
- `pre-commit run --files README.md docs/USAGE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684909cdc7cc8322abbadb9b1db6bf75