### PR TITLE
Improve doc cross links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Typical log output looks like:
 2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
 ```
 
-See [docs/USAGE.md](docs/USAGE.md) for more details and additional examples.
+## Documentation
+
+This README covers installation and quick-start examples. See
+[docs/USAGE.md](docs/USAGE.md) for extended usage instructions and additional
+examples.
 
 ## Contributing
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,18 +1,25 @@
 # Usage Guide
 
-This document expands on the information in the project README and demonstrates
-how to configure the crawler for different file types.
+This document expands on the information in the project
+[README](../README.md) and demonstrates how to configure the crawler for
+different file types.
 
 ## Downloading MP3 Samples
 
 The crawler targets source code files by default. To download MP3 files instead,
 set the `TARGET_EXTENSIONS` environment variable and specify the desired number
-of samples. The example below retrieves up to 50 MP3 files using direct HTTPS
-access.
+of samples. Below are examples for both PowerShell and the Windows command
+prompt. Each retrieves up to 50 MP3 files using direct HTTPS access.
 
-```bash
-CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 \
-TARGET_EXTENSIONS=.mp3 \
+```powershell
+$env:CRAWL_PREFIX = "crawl-data/CC-MAIN-2024-22"
+$env:TARGET_EXTENSIONS = ".mp3"
+python crawler.py --mode http --warcs 20 --samples 50
+```
+
+```batch
+set CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22
+set TARGET_EXTENSIONS=.mp3
 python crawler.py --mode http --warcs 20 --samples 50
 ```
 


### PR DESCRIPTION
## Summary
- clarify pointer to extended usage docs in README
- mention main README from the usage guide
- include PowerShell and Windows cmd examples in the usage guide

## Testing
- `pre-commit run --files docs/USAGE.md README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684909cdc7cc8322abbadb9b1db6bf75