### PR TITLE
Fix prefix duplication in list_warc_keys_http

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -395,7 +395,9 @@ def list_warc_keys_http(prefix: str, max_keys: int) -> List[str]:
                 for line in gz:
                     key = line.decode("utf-8").strip()
                     if key.endswith(".warc.gz"):
-                        keys.append(f"crawl-data/{key}")
+                        if not key.startswith("crawl-data/"):
+                            key = f"crawl-data/{key}"
+                        keys.append(key)
                         if len(keys) >= max_keys:
                             break
             return keys


### PR DESCRIPTION
## Summary
- avoid double prefixing WARC paths in `list_warc_keys_http`
- test reading prefixed `warc.paths.gz`

## Testing
- `pre-commit run --files utils.py tests/test_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490f30ee588322aa6581dee2066d89