### PR TITLE
Validate audio content in index mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Typical log output looks like:
 2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
 ```
 
+Only responses with an `audio/*` content type are written to disk.
+
 ## CDX index mode
 
 Instead of streaming entire WARC files you can fetch specific records using

--- a/crawler.py
+++ b/crawler.py
@@ -170,7 +170,12 @@ def main() -> None:
 
             stream = io.BytesIO(r.content)
             for rec in ArchiveIterator(stream, arc2warc=True):
-                if rec.rec_type == "response" and url.endswith(ext):
+                content_type = rec.http_headers.get_header("Content-Type", "")
+                if (
+                    rec.rec_type == "response"
+                    and content_type.startswith("audio/")
+                    and url.endswith(ext)
+                ):
                     data = rec.content_stream().read()
                     try:
                         save_file(data, url, OUTPUT_DIR)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -30,6 +30,8 @@ Typical output lines look like this:
 2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
 ```
 
+Files are only written if the response's `Content-Type` header starts with `audio/`.
+
 The downloaded files are written to the directory specified by `OUTPUT_DIR`
 (`./output` by default).
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -5,10 +5,11 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import crawler  # noqa: E402
-import utils  # noqa: E402
 from warcio.statusandheaders import StatusAndHeaders  # noqa: E402
 from warcio.warcwriter import WARCWriter  # noqa: E402
+
+import crawler  # noqa: E402
+import utils  # noqa: E402
 
 
 def _create_warc(path: Path, content_type: str, url: str) -> None:
@@ -30,7 +31,11 @@ def _process_bytes(data: bytes, url: str, ext: str, output_dir: str) -> bool:
     stream = io.BytesIO(data)
     for rec in crawler.ArchiveIterator(stream, arc2warc=True):
         content_type = rec.http_headers.get_header("Content-Type", "")
-        if rec.rec_type == "response" and content_type.startswith("audio/") and url.endswith(ext):
+        if (
+            rec.rec_type == "response"
+            and content_type.startswith("audio/")
+            and url.endswith(ext)
+        ):
             content = rec.content_stream().read()
             crawler.save_file(content, url, output_dir)
             return True

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,61 @@
+import gzip
+import io
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import crawler  # noqa: E402
+import utils  # noqa: E402
+from warcio.statusandheaders import StatusAndHeaders  # noqa: E402
+from warcio.warcwriter import WARCWriter  # noqa: E402
+
+
+def _create_warc(path: Path, content_type: str, url: str) -> None:
+    with path.open("wb") as fh:
+        gz = gzip.GzipFile(fileobj=fh, mode="wb")
+        writer = WARCWriter(gz, gzip=False)
+        headers = StatusAndHeaders("200 OK", [("Content-Type", content_type)])
+        record = writer.create_warc_record(
+            url,
+            "response",
+            payload=io.BytesIO(b"data"),
+            http_headers=headers,
+        )
+        writer.write_record(record)
+        gz.close()
+
+
+def _process_bytes(data: bytes, url: str, ext: str, output_dir: str) -> bool:
+    stream = io.BytesIO(data)
+    for rec in crawler.ArchiveIterator(stream, arc2warc=True):
+        content_type = rec.http_headers.get_header("Content-Type", "")
+        if rec.rec_type == "response" and content_type.startswith("audio/") and url.endswith(ext):
+            content = rec.content_stream().read()
+            crawler.save_file(content, url, output_dir)
+            return True
+    return False
+
+
+def test_index_mode_media_type(monkeypatch, tmp_path):
+    audio_warc = tmp_path / "audio.warc.gz"
+    text_warc = tmp_path / "text.warc.gz"
+    url = "http://example.com/sample.mp3"
+    _create_warc(audio_warc, "audio/mpeg", url)
+    _create_warc(text_warc, "text/plain", url)
+
+    saved = []
+
+    def fake_save(data: bytes, u: str, out: str) -> str:
+        path = utils.save_file(data, u, out)
+        saved.append(path)
+        return path
+
+    monkeypatch.setattr(crawler, "save_file", fake_save)
+    monkeypatch.setattr(crawler, "OUTPUT_DIR", str(tmp_path))
+
+    assert _process_bytes(audio_warc.read_bytes(), url, ".mp3", str(tmp_path))
+    assert len(saved) == 1
+
+    assert not _process_bytes(text_warc.read_bytes(), url, ".mp3", str(tmp_path))
+    assert len(saved) == 1


### PR DESCRIPTION
## Summary
- validate that index-mode records are audio before saving
- document media-type check in README and USAGE guide
- add test for index mode audio validation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684953fc04348322bdc58b673bf96d76