### PR TITLE
Remove unused path append in tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,8 +15,6 @@ from warcio.warcwriter import WARCWriter  # noqa: E402
 
 import utils  # noqa: E402
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 # Helper to create a small WARC file for testing
 
 


### PR DESCRIPTION
## Summary
- drop redundant `sys.path.append(...)` from `tests/test_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5366c37483228be0e437dfce4022