### PR TITLE
Change default index filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ the Common Crawl index:
 
 ```bash
 CRAWL_PREFIX=CC-MAIN-2024-22 \
-python crawler.py --mode index --samples 50 --extensions .mp3
+python crawler.py --mode index --samples 50
 ```
 
-Omit the `--extensions` option or pass an empty string to save any
-`audio/*` response regardless of the file name.
+All `audio/*` responses are saved by default. Use `--extensions` to
+filter by file name, for example `--extensions .mp3`.
 
 ## Documentation
 

--- a/crawler.py
+++ b/crawler.py
@@ -20,7 +20,10 @@ from utils import (
 S3_BUCKET = os.getenv("S3_BUCKET", "commoncrawl")
 CRAWL_PREFIX = os.getenv("CRAWL_PREFIX", "crawl-data")
 DEFAULT_CRAWL = "CC-MAIN-2024-22"
-DEFAULT_EXT = ".mp3"
+# When using the CDX index the crawler previously filtered by the `.mp3`
+# extension. The default is now an empty string so any `audio/*` response is
+# saved irrespective of the URL.
+DEFAULT_EXT = ""
 
 # Parse target extensions into a Python set
 _default_exts = ".py,.js,.java,.cpp,.go"
@@ -94,7 +97,7 @@ def main() -> None:
         dest="extensions",
         help=(
             "Extension for index mode (e.g., .mp3). "
-            "Use empty string to match all audio"
+            "Use empty string (default) to match all audio"
         ),
     )
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,8 +42,9 @@ individual records without streaming full WARC files:
 
 ```powershell
 $env:CRAWL_PREFIX = "CC-MAIN-2024-22"
-python crawler.py --mode index --samples 50 --extensions .mp3
+python crawler.py --mode index --samples 50
 ```
 
-Passing an empty string to `--extensions` disables the file extension check and
-saves any `audio/*` response.
+By default the crawler saves every `audio/*` response. Use the
+`--extensions` option to restrict downloads to matching file names, for
+example `--extensions .mp3`.


### PR DESCRIPTION
## Summary
- loosen default index filtering for audio files
- document new index default in README and USAGE
- tweak CLI help string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a550375c08322b19dda83c5ec115d