### PR TITLE
Refactor crawler for local WARC files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Programmer: Hasan Alqahtani
 
-CC Codex Crawler downloads files from the Common Crawl dataset and prepares them
-for further analysis. It provides a command line utility that streams WARC files
-and saves matching records to disk.
+CC Codex Crawler scans local Common Crawl WARC files and saves matching
+records to disk. Download your desired crawl segments manually and point the
+crawler at the directory containing the ``*.warc`` files.
 
 ```
 crawler.py --> utils.py --> OUTPUT_DIR
@@ -26,30 +26,23 @@ export OPENAI_API_KEY=<your key>
 
 ## Running the crawler
 
-The crawler can operate either with AWS credentials or via direct HTTPS
-requests. By default it searches for common source code extensions, but this can
-be customised via environment variables.
+The crawler operates on local files only. By default it searches for common
+source code extensions, but this can be customised via environment variables.
 
 The most common options are listed below:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `S3_BUCKET` | S3 bucket name | `commoncrawl` |
-| `CRAWL_PREFIX` | Crawl prefix when using `--mode http` | `crawl-data` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LOCAL_WARC_DIR` | Directory containing downloaded WARC files | `E:\\` |
 | `TARGET_EXTENSIONS` | Comma separated list of extensions to save | `.py,.js,.java,.cpp,.go` |
-| `OUTPUT_DIR` | Directory for downloaded files | `./output` |
+| `OUTPUT_DIR` | Directory for extracted files | `./output` |
 
-A simple crawl using AWS credentials:
-
-```bash
-python crawler.py --warcs 5 --samples 100
-```
-
-Using HTTPS mode without credentials (always specify a concrete crawl):
+A simple run processing five local WARC files:
 
 ```bash
-CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 \
-python crawler.py --mode http --warcs 5 --samples 100
+python crawler.py --warc-dir E:\\WARC-CC-MAIN-2024-30 --warcs 5 --samples 100
 ```
 
 ## Example: downloading MP3 files
@@ -58,9 +51,8 @@ To gather a small corpus of audio files, override the target extensions and
 request more WARC files. The following command fetches up to 50 MP3 samples:
 
 ```bash
-CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22 \
 TARGET_EXTENSIONS=.mp3 \
-python crawler.py --mode http --warcs 20 --samples 50
+python crawler.py --warc-dir E:\\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
 ```
 
 Typical log output looks like:
@@ -71,19 +63,6 @@ Typical log output looks like:
 ```
 
 Only responses with an `audio/*` content type are written to disk.
-
-## CDX index mode
-
-Instead of streaming entire WARC files you can fetch specific records using
-the Common Crawl index:
-
-```bash
-CRAWL_PREFIX=CC-MAIN-2024-22 \
-python crawler.py --mode index --samples 50
-```
-
-All `audio/*` responses are saved by default. Use `--extensions` to
-filter by file name, for example `--extensions .mp3`.
 
 ## Documentation
 

--- a/crawler.py
+++ b/crawler.py
@@ -1,43 +1,28 @@
-import io
-import json
 import os
-import time
-
-import requests
-from warcio.archiveiterator import ArchiveIterator
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
+import threading
 
 from utils import (
-    list_warc_keys,
-    list_warc_keys_http,
+    list_local_warc_files,
     load_state,
     save_file,
     save_state,
-    stream_and_extract,
-    stream_and_extract_http,
+    stream_and_extract_local,
 )
 
-# Configuration from environment variables with sensible defaults
-S3_BUCKET = os.getenv("S3_BUCKET", "commoncrawl")
-CRAWL_PREFIX = os.getenv("CRAWL_PREFIX", "crawl-data")
-DEFAULT_CRAWL = "CC-MAIN-2024-22"
-# When using the CDX index the crawler previously filtered by the `.mp3`
-# extension. The default is now an empty string so any `audio/*` response is
-# saved irrespective of the URL.
-DEFAULT_EXT = ""
-
-# Parse target extensions into a Python set
+# Configuration
+LOCAL_WARC_DIR = os.getenv("LOCAL_WARC_DIR", "E:\\")
 _default_exts = ".py,.js,.java,.cpp,.go"
 TARGET_EXTENSIONS = {
     ext.strip()
     for ext in os.getenv("TARGET_EXTENSIONS", _default_exts).split(",")
     if ext.strip()
 }
-
 OUTPUT_DIR = os.getenv("OUTPUT_DIR", "./output")
 MAX_WARCS = int(os.getenv("MAX_WARCS", "10"))
 SAMPLES_PER_EXT = int(os.getenv("SAMPLES_PER_EXT", "1000"))
-RATE_LIMIT_SECONDS = float(os.getenv("RATE_LIMIT_SECONDS", "1.0"))
-USER_AGENT = os.getenv("USER_AGENT", "cc-codex-crawler/1.0")
 MAX_WORKERS = int(os.getenv("MAX_WORKERS", "4"))
 STATE_FILE = os.getenv("STATE_FILE", "crawler_state.json")
 
@@ -45,22 +30,11 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 
 def main() -> None:
-    """Entry point for the CLI crawler.
-
-    The function parses command line arguments, configures logging and then
-    iterates over WARC files from the Common Crawl. Matching records are saved
-    to ``OUTPUT_DIR`` using :func:`save_file`.
-    """
+    """Process local WARC files and save matching records."""
 
     import argparse
-    import logging
-    import threading
-    from collections import defaultdict
-    from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    import boto3
-
-    parser = argparse.ArgumentParser(description="CC Codex crawler")
+    parser = argparse.ArgumentParser(description="CC Codex crawler (local)")
     parser.add_argument(
         "--warcs",
         type=int,
@@ -74,36 +48,19 @@ def main() -> None:
         help="Number of files to save per extension",
     )
     parser.add_argument(
-        "--rate-limit",
-        dest="rate_limit",
-        type=float,
-        default=RATE_LIMIT_SECONDS,
-        help="Seconds to sleep between requests",
-    )
-    parser.add_argument(
         "--workers",
         type=int,
         default=MAX_WORKERS,
         help="Maximum number of concurrent workers",
     )
     parser.add_argument(
-        "--mode",
-        choices=["aws", "http", "index"],
-        default="aws",
-        help="Access S3 via the AWS SDK, direct HTTPS or the CDX index",
-    )
-    parser.add_argument(
-        "--extensions",
-        dest="extensions",
-        help=(
-            "Extension for index mode (e.g., .mp3). "
-            "Use empty string (default) to match all audio"
-        ),
+        "--warc-dir",
+        default=LOCAL_WARC_DIR,
+        help="Directory containing local WARC files",
     )
 
     args = parser.parse_args()
 
-    # Configure logging: console handler and file handler
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -118,164 +75,48 @@ def main() -> None:
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 
-    if args.mode == "index":
-        crawl = os.getenv("CRAWL_PREFIX", DEFAULT_CRAWL)
-        ext = args.extensions or DEFAULT_EXT
-        # When ext is empty, any audio response is eligible for saving
-        idx_url = f"http://index.commoncrawl.org/{crawl}-index?url=*{ext}&output=json"
+    warc_files = list_local_warc_files(args.warc_dir, args.warcs)
 
-        attempt = 0
-        backoff = 1.0
-        while attempt < 3:
-            try:
-                resp = requests.get(idx_url, timeout=10)
-                resp.raise_for_status()
-                break
-            except (
-                requests.RequestException
-            ) as exc:  # pragma: no cover - network failure
-                attempt += 1
-                if attempt >= 3:
-                    logger.warning("Failed to query index: %s", exc)
-                    return
-                time.sleep(backoff)
-                backoff *= 2
+    completed = load_state(STATE_FILE)
+    if completed:
+        warc_files = [p for p in warc_files if p not in completed]
 
-        count = 0
-        for line in resp.text.splitlines():
-            if count >= args.samples:
-                break
-            entry = json.loads(line)
-            filename = entry["filename"]
-            offset = int(entry["offset"])
-            length = int(entry["length"])
-            url = entry["url"]
-
-            warc_url = f"https://data.commoncrawl.org/{filename}"
-            headers = {"Range": f"bytes={offset}-{offset + length - 1}"}
-
-            attempt2 = 0
-            backoff2 = 1.0
-            while attempt2 < 3:
-                try:
-                    r = requests.get(warc_url, headers=headers, timeout=10)
-                    r.raise_for_status()
-                    break
-                except (
-                    requests.RequestException
-                ) as exc:  # pragma: no cover - network failure
-                    attempt2 += 1
-                    if attempt2 >= 3:
-                        logger.warning("Failed to fetch range: %s", exc)
-                        r = None
-                        break
-                    time.sleep(backoff2)
-                    backoff2 *= 2
-
-            if not r:
-                continue
-
-            stream = io.BytesIO(r.content)
-            for rec in ArchiveIterator(stream, arc2warc=True):
-                content_type = rec.http_headers.get_header("Content-Type", "")
-                if (
-                    rec.rec_type == "response"
-                    and content_type.startswith("audio/")
-                    and (not ext or url.endswith(ext))
-                ):
-                    data = rec.content_stream().read()
-                    try:
-                        save_file(data, url, OUTPUT_DIR)
-                        count += 1
-                        logger.info("Saved %s (%d/%d)", url, count, args.samples)
-                    except Exception as exc:  # pragma: no cover - disk failure
-                        logger.warning("Failed to save %s: %s", url, exc)
-                    break
-        return
-
-    use_http = args.mode == "http"
-    s3_client = None
-    if args.mode == "aws":
-        s3_client = boto3.client("s3")
-
-    try:
-        if use_http:
-            prefix = os.getenv("CRAWL_PREFIX", CRAWL_PREFIX).strip("/")
-            warc_keys = list_warc_keys_http(prefix, args.warcs)
-        else:
-            warc_keys = list_warc_keys(s3_client, S3_BUCKET, CRAWL_PREFIX, args.warcs)
-    except Exception as exc:  # pragma: no cover - network failure
-        if not use_http:
-            logger.warning("Falling back to HTTP listing due to: %s", exc)
-            try:
-                prefix = os.getenv("CRAWL_PREFIX", CRAWL_PREFIX).strip("/")
-                warc_keys = list_warc_keys_http(prefix, args.warcs)
-                use_http = True
-            except Exception as exc2:
-                logger.warning("Failed to list WARC files: %s", exc2)
-                return
-        else:
-            logger.warning("Failed to list WARC files: %s", exc)
-            return
-
-    completed_keys = load_state(STATE_FILE)
-    if completed_keys:
-        warc_keys = [k for k in warc_keys if k not in completed_keys]
-
-    if not warc_keys:
+    if not warc_files:
         logger.info("No new WARC files to process")
         return
 
-    saved_counts = defaultdict(int)
+    saved_counts: defaultdict[str, int] = defaultdict(int)
     lock = threading.Lock()
     state_lock = threading.Lock()
 
-    def process_warc(key: str) -> None:
-        logger.info("Processing %s", key)
+    def process_warc(path: str) -> None:
+        logger.info("Processing %s", path)
         try:
-            if use_http:
-                iterator = stream_and_extract_http(
-                    key,
-                    TARGET_EXTENSIONS,
-                    args.rate_limit,
-                    USER_AGENT,
-                )
-            else:
-                iterator = stream_and_extract(
-                    s3_client,
-                    S3_BUCKET,
-                    key,
-                    TARGET_EXTENSIONS,
-                    args.rate_limit,
-                    USER_AGENT,
-                )
+            iterator = stream_and_extract_local(path, TARGET_EXTENSIONS)
             for url, data in iterator:
-                ext = next(
-                    (e for e in TARGET_EXTENSIONS if url.endswith(e)),
-                    None,
-                )
+                ext = next((e for e in TARGET_EXTENSIONS if url.endswith(e)), None)
                 if not ext:
                     continue
                 with lock:
                     if saved_counts[ext] >= args.samples:
                         continue
                 try:
-                    path = save_file(data, url, OUTPUT_DIR)
+                    target_path = save_file(data, url, OUTPUT_DIR)
                     with lock:
                         saved_counts[ext] += 1
-                    logger.info("Saved %s (%s)", path, ext)
-                except Exception as exc:  # pragma: no cover - disk failure
+                    logger.info("Saved %s (%s)", target_path, ext)
+                except Exception as exc:
                     logger.warning("Failed to save %s: %s", url, exc)
-        except Exception as exc:  # pragma: no cover - streaming failure
-            logger.warning("Error processing %s: %s", key, exc)
+        except Exception as exc:
+            logger.warning("Error processing %s: %s", path, exc)
         finally:
             with state_lock:
-                completed_keys.add(key)
-                save_state(STATE_FILE, completed_keys)
+                completed.add(path)
+                save_state(STATE_FILE, completed)
 
-    max_workers = min(args.workers, len(warc_keys)) or 1
+    max_workers = min(args.workers, len(warc_files)) or 1
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [executor.submit(process_warc, k) for k in warc_keys]
+        futures = [executor.submit(process_warc, p) for p in warc_files]
         for fut in as_completed(futures):
             fut.result()
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,19 +8,18 @@ different file types.
 
 The crawler targets source code files by default. To download MP3 files instead,
 set the `TARGET_EXTENSIONS` environment variable and specify the desired number
-of samples. Below are examples for both PowerShell and the Windows command
-prompt. Each retrieves up to 50 MP3 files using direct HTTPS access.
+of samples. Place your downloaded WARC files in a directory and point the
+crawler at it. The examples below retrieve up to 50 MP3 files from local
+archives.
 
 ```powershell
-$env:CRAWL_PREFIX = "crawl-data/CC-MAIN-2024-22"
 $env:TARGET_EXTENSIONS = ".mp3"
-python crawler.py --mode http --warcs 20 --samples 50
+python crawler.py --warc-dir E:\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
 ```
 
 ```batch
-set CRAWL_PREFIX=crawl-data/CC-MAIN-2024-22
 set TARGET_EXTENSIONS=.mp3
-python crawler.py --mode http --warcs 20 --samples 50
+python crawler.py --warc-dir E:\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
 ```
 
 Typical output lines look like this:
@@ -34,17 +33,3 @@ Files are only written if the response's `Content-Type` header starts with `audi
 
 The downloaded files are written to the directory specified by `OUTPUT_DIR`
 (`./output` by default).
-
-## CDX index mode
-
-When you only need a small sample you can use the CDX index to download
-individual records without streaming full WARC files:
-
-```powershell
-$env:CRAWL_PREFIX = "CC-MAIN-2024-22"
-python crawler.py --mode index --samples 50
-```
-
-By default the crawler saves every `audio/*` response. Use the
-`--extensions` option to restrict downloads to matching file names, for
-example `--extensions .mp3`.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import gzip
 import io
-import os
 from pathlib import Path
 
 import utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,32 +1,23 @@
 import gzip
 import io
 import os
-import sys
 from pathlib import Path
 
-sys.path.insert(
-    0,
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
-)  # noqa: E402
-import pytest  # noqa: E402
-import requests  # noqa: E402
-from warcio.statusandheaders import StatusAndHeaders  # noqa: E402
-from warcio.warcwriter import WARCWriter  # noqa: E402
+import utils
 
-import utils  # noqa: E402
-
-# Helper to create a small WARC file for testing
+from warcio.statusandheaders import StatusAndHeaders
+from warcio.warcwriter import WARCWriter
 
 
-def _create_warc(path: Path):
+def _create_warc(path: Path, content_type: str = "text/plain") -> None:
     with path.open("wb") as fh:
         gz = gzip.GzipFile(fileobj=fh, mode="wb")
         writer = WARCWriter(gz, gzip=False)
-        headers = StatusAndHeaders("200 OK", [("Content-Type", "text/plain")])
+        headers = StatusAndHeaders("200 OK", [("Content-Type", content_type)])
         record = writer.create_warc_record(
-            "http://example.com/test.py",
+            "http://example.com/test.mp3",
             "response",
-            payload=io.BytesIO(b"print(1)"),
+            payload=io.BytesIO(b"audio"),
             http_headers=headers,
         )
         writer.write_record(record)
@@ -34,12 +25,9 @@ def _create_warc(path: Path):
 
 
 def test_extension_from_url_present():
-    ext_func = getattr(utils, "extension_from_url", None)
-    if ext_func is None:
-        pytest.skip("extension_from_url not implemented")
-    assert ext_func("https://example.com/code.py") == ".py"
-    assert ext_func("https://example.com/path/file.tar.gz") in {".tar.gz", ".gz"}
-    assert ext_func("https://example.com/a/b/?q=1") == ""
+    assert utils.extension_from_url("https://example.com/file.py") == ".py"
+    assert utils.extension_from_url("https://x/y/file.tar.gz") in {".tar.gz", ".gz"}
+    assert utils.extension_from_url("https://example.com/a/?q=1") == ""
 
 
 def test_save_file_collision(tmp_path):
@@ -52,189 +40,21 @@ def test_save_file_collision(tmp_path):
     assert (tmp_path / "hello_1.py").read_bytes() == b"two"
 
 
-def test_list_warc_keys():
-    pages = [
-        {"Contents": [{"Key": "a.warc.gz"}, {"Key": "b.txt"}]},
-        {"Contents": [{"Key": "c.warc.gz"}]},
-    ]
-
-    class Paginator:
-        def paginate(self, Bucket, Prefix):
-            assert Bucket == "bucket"
-            assert Prefix == "prefix"
-            for p in pages:
-                yield p
-
-    class Client:
-        def get_paginator(self, name):
-            assert name == "list_objects_v2"
-            return Paginator()
-
-    result = utils.list_warc_keys(Client(), "bucket", "prefix", 2)
-    assert result == ["a.warc.gz", "c.warc.gz"]
+def test_list_local_warc_files(tmp_path):
+    d = tmp_path / "a"
+    d.mkdir()
+    f1 = d / "one.warc"
+    f1.write_bytes(b"data")
+    f2 = d / "two.warc.gz"
+    f2.write_bytes(b"data")
+    files = utils.list_local_warc_files(str(tmp_path), 5)
+    assert set(files) == {str(f1), str(f2)}
 
 
-def test_stream_and_extract(tmp_path, monkeypatch):
-    warc_path = tmp_path / "sample.warc.gz"
-    _create_warc(warc_path)
-
-    class FakeClient:
-        def generate_presigned_url(self, op, Params, ExpiresIn):
-            return "http://example.com/presigned"
-
-    class DummyResp:
-        def __init__(self, path):
-            self.raw = open(path, "rb")
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            self.raw.close()
-
-    def fake_get(url, stream=True, headers=None, timeout=None):
-        assert url == "http://example.com/presigned"
-        assert timeout == utils.REQUEST_TIMEOUT
-        return DummyResp(warc_path)
-
-    monkeypatch.setattr("requests.get", fake_get)
-
-    records = list(
-        utils.stream_and_extract(
-            FakeClient(),
-            "bucket",
-            "key",
-            [".py"],
-            rate_limit=0,
-            user_agent="ua",
-        )
-    )
+def test_stream_and_extract_local(tmp_path):
+    warc = tmp_path / "sample.warc.gz"
+    _create_warc(warc, "audio/mpeg")
+    records = list(utils.stream_and_extract_local(str(warc), [".mp3"]))
     assert len(records) == 1
-    assert records[0][0] == "http://example.com/test.py"
-    assert records[0][1] == b"print(1)"
-
-
-def test_list_warc_keys_http(tmp_path, monkeypatch):
-    path_file = tmp_path / "warc.paths.gz"
-    content = b"a.warc.gz\nb.warc.gz\n"
-    import gzip
-
-    with gzip.open(path_file, "wb") as fh:
-        fh.write(content)
-
-    class Resp:
-        def __init__(self, data):
-            self.content = data
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
-
-    calls = []
-
-    def fake_get(url, timeout=10):
-        calls.append(1)
-        assert url.endswith("warc.paths.gz")
-        if len(calls) == 1:
-            raise requests.RequestException("fail")
-        return Resp(path_file.read_bytes())
-
-    monkeypatch.setattr("requests.get", fake_get)
-    monkeypatch.setattr("time.sleep", lambda x: None)
-
-    keys = utils.list_warc_keys_http("crawl-data/CC-MAIN-2020-50", 1)
-    assert calls and len(calls) == 2
-    assert keys == ["crawl-data/a.warc.gz"]
-
-
-def test_list_warc_keys_http_prefixed_entries(tmp_path, monkeypatch):
-    path_file = tmp_path / "warc.paths.gz"
-    content = b"crawl-data/a.warc.gz\ncrawl-data/b.warc.gz\n"
-    import gzip
-
-    with gzip.open(path_file, "wb") as fh:
-        fh.write(content)
-
-    class Resp:
-        def __init__(self, data):
-            self.content = data
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
-
-    def fake_get(url, timeout=10):
-        assert url.endswith("warc.paths.gz")
-        return Resp(path_file.read_bytes())
-
-    monkeypatch.setattr("requests.get", fake_get)
-
-    keys = utils.list_warc_keys_http("crawl-data/CC-MAIN-XXXX-XX", 2)
-    assert keys == ["crawl-data/a.warc.gz", "crawl-data/b.warc.gz"]
-
-
-def test_list_warc_keys_http_latest_404(monkeypatch):
-    class Resp:
-        def __init__(self):
-            self.status_code = 404
-            self.content = b""
-
-        def raise_for_status(self):
-            raise requests.HTTPError(response=self)
-
-    def fake_get(url, timeout=10):
-        return Resp()
-
-    monkeypatch.setattr("requests.get", fake_get)
-
-    with pytest.raises(RuntimeError):
-        utils.list_warc_keys_http("crawl-data", 1)
-
-
-def test_stream_and_extract_http(tmp_path, monkeypatch):
-    warc_path = tmp_path / "sample.warc.gz"
-    _create_warc(warc_path)
-
-    class DummyResp:
-        def __init__(self, path):
-            self.raw = open(path, "rb")
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            self.raw.close()
-
-    calls = []
-
-    def fake_get(url, stream=True, headers=None, timeout=None):
-        calls.append(1)
-        assert url == "https://data.commoncrawl.org/crawl-data/dir/sample.warc.gz"
-        assert timeout == utils.REQUEST_TIMEOUT
-        if len(calls) == 1:
-            raise requests.RequestException("fail")
-        return DummyResp(warc_path)
-
-    monkeypatch.setattr("requests.get", fake_get)
-    monkeypatch.setattr("time.sleep", lambda x: None)
-
-    records = list(
-        utils.stream_and_extract_http(
-            "crawl-data/dir/sample.warc.gz",
-            [".py"],
-            rate_limit=0,
-            user_agent="ua",
-        )
-    )
-    assert calls and len(calls) == 2
-    assert len(records) == 1
-    assert records[0][0] == "http://example.com/test.py"
-    assert records[0][1] == b"print(1)"
+    assert records[0][0] == "http://example.com/test.mp3"
+    assert records[0][1] == b"audio"


### PR DESCRIPTION
## Summary
- rework crawler to only process local WARC files
- drop networking and index functionality
- update README and usage documentation
- add helpers `list_local_warc_files` and `stream_and_extract_local`
- rewrite unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd63aca0c832282f9f3e86e87935d