### PR TITLE
Sequential WARC scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ TARGET_EXTENSIONS=.mp3 \
 python crawler.py --warc-dir E:\\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
 ```
 
+The crawler processes one WARC file at a time and moves on to the next only
+when the requested number of samples hasn't yet been collected. It stops early
+once enough matches are found or no further WARC files remain.
+
 Typical log output looks like:
 
 ```


### PR DESCRIPTION
## Summary
- process WARC files sequentially until the desired number of samples is found
- clarify README about sequential processing logic

## Testing
- `pre-commit run --files crawler.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdb9077a88322a2a5d6e8941421a2