### PR TITLE
Fix README table duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The most common options are listed below:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| Variable | Description | Default |
-|----------|-------------|---------|
 | `LOCAL_WARC_DIR` | Directory containing downloaded WARC files | `E:\\` |
 | `TARGET_EXTENSIONS` | Comma separated list of extensions to save | `.py,.js,.java,.cpp,.go` |
 | `OUTPUT_DIR` | Directory for extracted files | `./output` |


### PR DESCRIPTION
## Summary
- clean up extra header rows in README usage options table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'warcio')*

------
https://chatgpt.com/codex/tasks/task_e_684be07a423483229a11e167c89e04f1