### PR TITLE
Remove unused workers option

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -21,7 +21,6 @@ TARGET_EXTENSIONS = {
 OUTPUT_DIR = os.getenv("OUTPUT_DIR", "./output")
 MAX_WARCS = int(os.getenv("MAX_WARCS", "10"))
 SAMPLES_PER_EXT = int(os.getenv("SAMPLES_PER_EXT", "1000"))
-MAX_WORKERS = int(os.getenv("MAX_WORKERS", "4"))
 STATE_FILE = os.getenv("STATE_FILE", "crawler_state.json")
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -44,12 +43,6 @@ def main() -> None:
         type=int,
         default=SAMPLES_PER_EXT,
         help="Number of files to save per extension",
-    )
-    parser.add_argument(
-        "--workers",
-        type=int,
-        default=MAX_WORKERS,
-        help="Maximum number of concurrent workers",
     )
     parser.add_argument(
         "--warc-dir",

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -6,10 +6,11 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import crawler  # noqa: E402
-import utils  # noqa: E402
 from warcio.statusandheaders import StatusAndHeaders  # noqa: E402
 from warcio.warcwriter import WARCWriter  # noqa: E402
+
+import crawler  # noqa: E402
+import utils  # noqa: E402
 
 
 def _create_warc(path: Path, content_type: str, url: str) -> None:
@@ -60,4 +61,3 @@ def test_main_local(monkeypatch, tmp_path):
 
     crawler.main()
     assert len(saved) == 1
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,10 @@ import gzip
 import io
 from pathlib import Path
 
-import utils
-
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.warcwriter import WARCWriter
+
+import utils
 
 
 def _create_warc(path: Path, content_type: str = "text/plain") -> None:


### PR DESCRIPTION
## Summary
- remove `MAX_WORKERS` constant and CLI option
- format tests with pre-commit hooks

## Testing
- `pre-commit run --files crawler.py README.md docs/USAGE.md tests/test_crawler.py tests/test_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be245fe38832289f2107950f433c4