### PR TITLE
Add missing WARC download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ Typical log output looks like:
 
 Only responses with an `audio/*` content type are written to disk.
 
+### Downloading missing WARC files
+
+Provide a crawl prefix with `--prefix` to automatically download WARC files
+from the Common Crawl bucket when they are not present locally. Files are saved
+under subdirectories named after each WARC file:
+
+```bash
+python crawler.py \
+  --warc-dir /data/warc \
+  --prefix CC-MAIN-2025-21 \
+  --warcs 20 --samples 100
+```
+
 ## Documentation
 
 This README covers installation and quick-start examples. See

--- a/crawler.py
+++ b/crawler.py
@@ -3,7 +3,9 @@ import os
 from collections import defaultdict
 
 from utils import (
+    download_warc_http,
     list_local_warc_files,
+    list_warc_keys_http,
     load_state,
     save_file,
     save_state,
@@ -49,6 +51,10 @@ def main() -> None:
         default=LOCAL_WARC_DIR,
         help="Directory containing local WARC files",
     )
+    parser.add_argument(
+        "--prefix",
+        help="Common Crawl prefix used to download missing WARC files",
+    )
 
     args = parser.parse_args()
 
@@ -68,6 +74,23 @@ def main() -> None:
 
     warc_files = list_local_warc_files(args.warc_dir, args.warcs)
 
+    if len(warc_files) < args.warcs and args.prefix:
+        keys = list_warc_keys_http(args.prefix, args.warcs)
+        for key in keys:
+            fname = os.path.basename(key)
+            local_path = os.path.join(args.warc_dir, fname)
+            if local_path not in warc_files:
+                if not os.path.exists(local_path):
+                    try:
+                        logger.info("Downloading %s", key)
+                        download_warc_http(key, local_path)
+                    except Exception as exc:
+                        logger.warning("Failed to download %s: %s", key, exc)
+                        continue
+                warc_files.append(local_path)
+                if len(warc_files) >= args.warcs:
+                    break
+
     completed = load_state(STATE_FILE)
     if completed:
         warc_files = [p for p in warc_files if p not in completed]
@@ -82,6 +105,13 @@ def main() -> None:
         logger.info("Processing %s", path)
         try:
             iterator = stream_and_extract_local(path, TARGET_EXTENSIONS)
+            base = os.path.basename(path)
+            if base.endswith(".warc.gz"):
+                base = base[:-8]
+            elif base.endswith(".warc"):
+                base = base[:-5]
+            sub_output_dir = os.path.join(OUTPUT_DIR, base)
+            os.makedirs(sub_output_dir, exist_ok=True)
             for url, data in iterator:
                 ext = next((e for e in TARGET_EXTENSIONS if url.endswith(e)), None)
                 if not ext:
@@ -89,7 +119,7 @@ def main() -> None:
                 if saved_counts[ext] >= args.samples:
                     continue
                 try:
-                    target_path = save_file(data, url, OUTPUT_DIR)
+                    target_path = save_file(data, url, sub_output_dir)
                     saved_counts[ext] += 1
                     logger.info("Saved %s (%s)", target_path, ext)
                 except Exception as exc:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -61,3 +61,6 @@ def test_main_local(monkeypatch, tmp_path):
 
     crawler.main()
     assert len(saved) == 1
+    subdir = out_dir / "audio"
+    assert subdir.is_dir()
+    assert saved[0].startswith(str(subdir))


### PR DESCRIPTION
## Summary
- add function to download WARC files via HTTPS
- save files under subdirectories per processed WARC
- automatically fetch missing WARC files when using `--prefix`
- document new behaviour in README
- test utilities and crawler updates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be6a7f578832299b2a008320b0734