### PR TITLE
Introduce index-based fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 Programmer: Hasan Alqahtani
 
-CC Codex Crawler scans local Common Crawl WARC files and saves matching
-records to disk. Download your desired crawl segments manually and point the
-crawler at the directory containing the ``*.warc`` files.
-
-```
-crawler.py --> utils.py --> OUTPUT_DIR
-```
+CC Codex Crawler provides a small Python utility for extracting files from the
+Common Crawl dataset.  Earlier versions only operated on local WARC files.
+The project now includes a lightweight fetcher inspired by
+[`commoncrawl-fetcher-lite`](https://github.com/tballison/commoncrawl-fetcher-lite)
+which downloads records based on the public indices.
 
 ## Installation
 
@@ -24,60 +22,36 @@ Optionally set an OpenAI API key if you plan to use the optional utilities:
 export OPENAI_API_KEY=<your key>
 ```
 
-## Running the crawler
+## Running the fetcher
 
-The crawler operates on local files only. By default it searches for common
-source code extensions, but this can be customised via environment variables.
+The new `fetcher.py` script reads a JSON configuration that lists the desired
+index files and filtering rules.  A minimal configuration looks like:
 
-The most common options are listed below:
+```json
+{
+  "dryRun": true,
+  "indices": {"paths": ["crawl-data/CC-MAIN-2023-06/cc-index.paths.gz"]},
+  "recordSelector": {
+    "must": {"status": [{"match": "200"}]},
+    "should": {"mime_detected": [{"match": "video/mp4"}]}
+  }
+}
+```
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `LOCAL_WARC_DIR` | Directory containing downloaded WARC files | `E:\\` |
-| `TARGET_EXTENSIONS` | Comma separated list of extensions to save | `.py,.js,.java,.cpp,.go` |
-| `OUTPUT_DIR` | Directory for extracted files | `./output` |
-
-A simple run processing five local WARC files:
+Run the fetcher with:
 
 ```bash
-python crawler.py --warc-dir E:\\WARC-CC-MAIN-2024-30 --warcs 5 --samples 100
+python fetcher.py path/to/config.json
 ```
 
-## Example: downloading MP3 files
+If `dryRun` is set to `false` the matching files are downloaded and stored in
+the directory specified by `outputDir`.
 
-To gather a small corpus of audio files, override the target extensions and
-request more WARC files. The following command fetches up to 50 MP3 samples:
+### Local crawler
 
-```bash
-TARGET_EXTENSIONS=.mp3 \
-python crawler.py --warc-dir E:\\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
-```
-
-The crawler processes one WARC file at a time and moves on to the next only
-when the requested number of samples hasn't yet been collected. It stops early
-once enough matches are found or no further WARC files remain.
-
-Typical log output looks like:
-
-```
-2025-06-11 00:00:00,000 - INFO - Processing crawl-data/.../sample.warc.gz
-2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
-```
-
-Only responses with an `audio/*` content type are written to disk.
-
-### Downloading missing WARC files
-
-Provide a crawl prefix with `--prefix` to automatically download WARC files
-from the Common Crawl bucket when they are not present locally. Files are saved
-under subdirectories named after each WARC file:
-
-```bash
-python crawler.py \
-  --warc-dir /data/warc \
-  --prefix CC-MAIN-2025-21 \
-  --warcs 20 --samples 100
-```
+The previous local crawler is still available as `crawler.py`. It scans local
+WARC files and saves matching records based on file extension. See
+`docs/USAGE.md` for details.
 
 ## Documentation
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,35 +1,20 @@
 # Usage Guide
 
-This document expands on the information in the project
-[README](../README.md) and demonstrates how to configure the crawler for
-different file types.
+This document expands on the [README](../README.md) and demonstrates how to
+run the simplified Common Crawl fetcher.
 
-## Downloading MP3 Samples
+## Running the Fetcher
 
-The crawler targets source code files by default. To download MP3 files instead,
-set the `TARGET_EXTENSIONS` environment variable and specify the desired number
-of samples. Place your downloaded WARC files in a directory and point the
-crawler at it. The examples below retrieve up to 50 MP3 files from local
-archives.
+Create a JSON configuration file describing which records to extract from the
+Common Crawl indices. A minimal example that lists MP4 files without actually
+downloading them is provided at `docs/minimal-config.json`.
 
-```powershell
-$env:TARGET_EXTENSIONS = ".mp3"
-python crawler.py --warc-dir E:\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
+Run the fetcher by passing the configuration file:
+
+```bash
+python fetcher.py docs/minimal-config.json
 ```
 
-```batch
-set TARGET_EXTENSIONS=.mp3
-python crawler.py --warc-dir E:\WARC-CC-MAIN-2024-30 --warcs 20 --samples 50
-```
-
-Typical output lines look like this:
-
-```
-2025-06-11 00:00:00,000 - INFO - Processing crawl-data/.../sample.warc.gz
-2025-06-11 00:00:10,000 - INFO - Saved output/track_001.mp3 (.mp3)
-```
-
-Files are only written if the response's `Content-Type` header starts with `audio/`.
-
-The downloaded files are written to the directory specified by `OUTPUT_DIR`
-(`./output` by default).
+Set `"dryRun": false` in the configuration to download matching files. The
+files will be written to the directory specified by `outputDir` (defaults to
+`docs/`).

--- a/docs/minimal-config.json
+++ b/docs/minimal-config.json
@@ -1,0 +1,14 @@
+{
+  "dryRun": true,
+  "indices": {
+    "paths": ["crawl-data/CC-MAIN-2023-06/cc-index.paths.gz"]
+  },
+  "recordSelector": {
+    "must": {
+      "status": [{"match": "200"}]
+    },
+    "should": {
+      "mime_detected": [{"match": "video/mp4"}]
+    }
+  }
+}

--- a/fetcher.py
+++ b/fetcher.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Simplified Common Crawl fetcher using index files.
+
+This module implements a very small subset of the features provided by
+`tballison/commoncrawl-fetcher-lite`.  It allows selecting records from
+Common Crawl index segments via a JSON configuration file and downloads
+matching files with HTTP range requests.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, List, Optional
+
+import requests
+from warcio.archiveiterator import ArchiveIterator
+
+from utils import REQUEST_TIMEOUT, save_file
+
+BASE_URL = "https://data.commoncrawl.org"
+
+
+@dataclass
+class RecordSelector:
+    must: Dict[str, List[str]]
+    should: Dict[str, List[str]]
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "RecordSelector":
+        def _load(section: Optional[Dict[str, List[Dict[str, str]]]]) -> Dict[str, List[str]]:
+            out: Dict[str, List[str]] = {}
+            if not section:
+                return out
+            for field, conditions in section.items():
+                out[field] = [c.get("match") for c in conditions if "match" in c]
+            return out
+
+        return cls(must=_load(data.get("must")), should=_load(data.get("should")))
+
+    def matches(self, record: Dict[str, str]) -> bool:
+        for field, values in self.must.items():
+            if record.get(field) not in values:
+                return False
+        if not self.should:
+            return True
+        for field, values in self.should.items():
+            if record.get(field) in values:
+                return True
+        return False
+
+
+def _open_gzip_stream(path_or_url: str) -> Iterator[bytes]:
+    if os.path.exists(path_or_url):
+        fh = open(path_or_url, "rb")
+    else:
+        resp = requests.get(path_or_url, stream=True, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        fh = resp.raw
+    with gzip.GzipFile(fileobj=fh) as gz:
+        for line in gz:
+            yield line
+
+
+def _iter_index_paths(entry: str) -> Iterator[str]:
+    prefix = BASE_URL
+    if os.path.exists(entry):
+        for line in _open_gzip_stream(entry):
+            yield line.decode("utf-8").strip()
+    else:
+        url = f"{prefix}/{entry.lstrip('/') }"
+        for line in _open_gzip_stream(url):
+            yield line.decode("utf-8").strip()
+
+
+def _iter_records(index_path: str) -> Iterator[Dict[str, str]]:
+    for line in _open_gzip_stream(index_path):
+        decoded = line.decode("utf-8")
+        try:
+            urlkey, rest = decoded.split(" ", 1)
+            timestamp, js = rest.split(" ", 1)
+            record = json.loads(js)
+            record["urlkey"] = urlkey
+            record["timestamp"] = timestamp
+            yield record
+        except Exception:
+            continue
+
+
+def _fetch_warc_slice(record: Dict[str, str], data_dir: Optional[str] = None) -> bytes:
+    filename = record["filename"]
+    offset = int(record["offset"])
+    length = int(record["length"])
+    if data_dir and os.path.exists(os.path.join(data_dir, os.path.basename(filename))):
+        path = os.path.join(data_dir, os.path.basename(filename))
+        with open(path, "rb") as fh:
+            fh.seek(offset)
+            return fh.read(length)
+    url = f"{BASE_URL}/{filename}"
+    headers = {"Range": f"bytes={offset}-{offset + length - 1}"}
+    resp = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    return resp.content
+
+
+def _extract_file(warc_bytes: bytes) -> Optional[tuple[str, bytes]]:
+    with gzip.GzipFile(fileobj=io.BytesIO(warc_bytes)) as gz:
+        for rec in ArchiveIterator(gz):
+            if rec.rec_type != "response":
+                continue
+            uri = rec.rec_headers.get_header("WARC-Target-URI")
+            if not uri:
+                continue
+            return uri, rec.content_stream().read()
+    return None
+
+
+def process_config(config_path: str, data_dir: Optional[str] = None) -> None:
+    with open(config_path, "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+
+    dry_run = bool(cfg.get("dryRun"))
+    selector = RecordSelector.from_dict(cfg.get("recordSelector", {}))
+    index_entries = cfg.get("indices", {}).get("paths", [])
+    out_dir = cfg.get("outputDir", "docs")
+    os.makedirs(out_dir, exist_ok=True)
+
+    for entry in index_entries:
+        for index_path in _iter_index_paths(entry):
+            for record in _iter_records(index_path):
+                if not selector.matches(record):
+                    continue
+                if dry_run:
+                    print(record.get("url"))
+                    continue
+                try:
+                    chunk = _fetch_warc_slice(record, data_dir)
+                    extracted = _extract_file(chunk)
+                    if not extracted:
+                        continue
+                    url, data = extracted
+                    save_file(data, url, out_dir)
+                except Exception as exc:
+                    print(f"Failed {record.get('url')}: {exc}")
+                time.sleep(1)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch files from Common Crawl")
+    parser.add_argument("config", help="JSON configuration file")
+    parser.add_argument(
+        "--data-dir",
+        help="Optional local directory containing referenced WARC files",
+    )
+
+    args = parser.parse_args()
+    process_config(args.config, args.data_dir)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,81 @@
+import gzip
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from warcio.statusandheaders import StatusAndHeaders
+from warcio.warcwriter import WARCWriter
+
+import fetcher
+
+
+def _create_warc(path: Path, content_type: str, url: str) -> int:
+    with path.open("wb") as fh:
+        gz = gzip.GzipFile(fileobj=fh, mode="wb")
+        writer = WARCWriter(gz, gzip=False)
+        headers = StatusAndHeaders("200 OK", [("Content-Type", content_type)])
+        record = writer.create_warc_record(
+            url,
+            "response",
+            payload=io.BytesIO(b"data"),
+            http_headers=headers,
+        )
+        writer.write_record(record)
+        gz.close()
+    return path.stat().st_size
+
+
+def test_process_config_local(tmp_path, monkeypatch):
+    warc = tmp_path / "sample.warc.gz"
+    length = _create_warc(warc, "video/mp4", "http://example.com/test.mp4")
+
+    index = tmp_path / "index.gz"
+    line = (
+        "com,example)/test.mp4 20250101000000 "
+        + json.dumps(
+            {
+                "url": "http://example.com/test.mp4",
+                "mime": "video/mp4",
+                "mime-detected": "video/mp4",
+                "status": "200",
+                "digest": "AAAA",
+                "length": str(length),
+                "offset": "0",
+                "filename": warc.name,
+            }
+        )
+        + "\n"
+    )
+    with gzip.open(index, "wb") as fh:
+        fh.write(line.encode("utf-8"))
+
+    paths = tmp_path / "cc-index.paths.gz"
+    with gzip.open(paths, "wb") as fh:
+        fh.write(f"{index.name}\n".encode("utf-8"))
+
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "dryRun": False,
+                "outputDir": str(tmp_path / "out"),
+                "indices": {"paths": [str(paths)]},
+                "recordSelector": {
+                    "must": {"status": [{"match": "200"}]},
+                    "should": {"mime-detected": [{"match": "video/mp4"}]},
+                },
+            }
+        )
+    )
+
+    monkeypatch.chdir(tmp_path)
+    fetcher.process_config(str(config), data_dir=str(tmp_path))
+
+    out_files = list((tmp_path / "out").iterdir())
+    assert len(out_files) == 1
+    assert out_files[0].read_bytes() == b"data"
+


### PR DESCRIPTION
## Summary
- add new `fetcher.py` inspired by commoncrawl-fetcher-lite
- document new fetcher in README and usage docs
- provide minimal JSON config example
- add unit test covering the fetcher

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5055798c83229cb927f964dc3fb9