### PR TITLE
Fix _iter_index_paths url join

### DIFF
--- a/fetcher.py
+++ b/fetcher.py
@@ -77,8 +77,6 @@ def _iter_index_paths(entry: str) -> Iterator[str]:
 
         url = f"{prefix}/{entry.lstrip('/')}"
 
-        url = f"{prefix}/{entry.lstrip('/') }"
-
         for line in _open_gzip_stream(url):
             yield line.decode("utf-8").strip()
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -79,3 +79,18 @@ def test_process_config_local(tmp_path, monkeypatch):
     assert len(out_files) == 1
     assert out_files[0].read_bytes() == b"data"
 
+
+def test_iter_index_paths_url(monkeypatch):
+    calls = []
+
+    def fake_open(path):
+        calls.append(path)
+        yield b"entry\n"
+
+    monkeypatch.setattr(fetcher, "_open_gzip_stream", fake_open)
+    monkeypatch.setattr(fetcher.os.path, "exists", lambda p: False)
+
+    result = list(fetcher._iter_index_paths("/foo/bar.gz"))
+
+    assert result == ["entry"]
+    assert calls == [f"{fetcher.BASE_URL}/foo/bar.gz"]


### PR DESCRIPTION
## Summary
- remove duplicate url assignment in `_iter_index_paths`
- test that `_iter_index_paths` joins URLs correctly

## Testing
- `pre-commit run --files fetcher.py tests/test_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6e83aa7c8322aa9f1c84a925bf5e