### PR TITLE
Add test for whitespace in index paths

### DIFF
--- a/fetcher.py
+++ b/fetcher.py
@@ -70,12 +70,13 @@ def _open_gzip_stream(path_or_url: str) -> Iterator[bytes]:
 
 def _iter_index_paths(entry: str) -> Iterator[str]:
     prefix = BASE_URL
-    if os.path.exists(entry):
-        for line in _open_gzip_stream(entry):
+    cleaned = entry.strip()
+    if os.path.exists(cleaned):
+        for line in _open_gzip_stream(cleaned):
             yield line.decode("utf-8").strip()
     else:
 
-        url = f"{prefix}/{entry.lstrip('/')}"
+        url = f"{prefix}/{cleaned.lstrip('/')}"
 
         for line in _open_gzip_stream(url):
             yield line.decode("utf-8").strip()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -94,3 +94,19 @@ def test_iter_index_paths_url(monkeypatch):
 
     assert result == ["entry"]
     assert calls == [f"{fetcher.BASE_URL}/foo/bar.gz"]
+
+
+def test_iter_index_paths_http(monkeypatch):
+    calls = []
+
+    def fake_open(path):
+        calls.append(path)
+        yield b"entry\n"
+
+    monkeypatch.setattr(fetcher, "_open_gzip_stream", fake_open)
+    monkeypatch.setattr(fetcher.os.path, "exists", lambda p: False)
+
+    result = list(fetcher._iter_index_paths("path/to/index.gz "))
+
+    assert result == ["entry"]
+    assert calls == [f"{fetcher.BASE_URL}/path/to/index.gz"]


### PR DESCRIPTION
## Summary
- handle whitespace in `_iter_index_paths`
- add `test_iter_index_paths_http` to ensure paths are trimmed before joining the base URL

## Testing
- `pre-commit run --files fetcher.py tests/test_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6eabaa7c8322b7843993c754a16c