### PR TITLE
Add must_not selector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ extract from the Common Crawl indices. A default example is provided as
   "indices": {"paths": ["crawl-data/CC-MAIN-2023-06/cc-index.paths.gz"]},
   "recordSelector": {
     "must": {"status": [{"match": "200"}]},
+    "must_not": {"mime": [{"match": "video/avi"}]},
     "should": {"mime-detected": [{"match": "video/mp4"}]}
   }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,3 +18,14 @@ python fetcher.py config.json
 Set `"dryRun": false` in the configuration to download matching files. The
 files will be written to the directory specified by `outputDir` (defaults to
 `docs/`).
+
+The `recordSelector` section also supports a `must_not` block to exclude
+records matching specific fields, e.g. to skip AVI videos:
+
+```json
+"recordSelector": {
+  "must": {"status": [{"match": "200"}]},
+  "must_not": {"mime": [{"match": "video/avi"}]},
+  "should": {"mime-detected": [{"match": "video/mp4"}]}
+}
+```

--- a/fetcher.py
+++ b/fetcher.py
@@ -28,6 +28,7 @@ BASE_URL = "https://data.commoncrawl.org"
 @dataclass
 class RecordSelector:
     must: Dict[str, List[str]]
+    must_not: Dict[str, List[str]]
     should: Dict[str, List[str]]
 
     @classmethod
@@ -42,11 +43,18 @@ class RecordSelector:
                 out[field] = [c.get("match") for c in conditions if "match" in c]
             return out
 
-        return cls(must=_load(data.get("must")), should=_load(data.get("should")))
+        return cls(
+            must=_load(data.get("must")),
+            must_not=_load(data.get("must_not")),
+            should=_load(data.get("should")),
+        )
 
     def matches(self, record: Dict[str, str]) -> bool:
         for field, values in self.must.items():
             if record.get(field) not in values:
+                return False
+        for field, values in self.must_not.items():
+            if record.get(field) in values:
                 return False
         if not self.should:
             return True

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -110,3 +110,17 @@ def test_iter_index_paths_http(monkeypatch):
 
     assert result == ["entry"]
     assert calls == [f"{fetcher.BASE_URL}/path/to/index.gz"]
+
+
+def test_recordselector_must_not():
+    selector = fetcher.RecordSelector.from_dict(
+        {
+            "must": {"status": [{"match": "200"}]},
+            "must_not": {"mime": [{"match": "video/avi"}]},
+            "should": {"mime-detected": [{"match": "video/mp4"}]},
+        }
+    )
+    record = {"status": "200", "mime": "video/mp4", "mime-detected": "video/mp4"}
+    assert selector.matches(record)
+    record["mime"] = "video/avi"
+    assert not selector.matches(record)


### PR DESCRIPTION
## Summary
- support `must_not` filtering in `RecordSelector`
- document the new feature in README and USAGE
- test the new `must_not` functionality

## Testing
- `pre-commit run --files fetcher.py tests/test_fetcher.py README.md docs/USAGE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e79e9fa10832293f01764c1b7f85a