### PR TITLE
Add async Common Crawl streaming processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ If `dryRun` is set to `false` the matching files are downloaded and stored in
 the directory specified by `outputDir`.
 
 
+## Streaming Processor
+
+`streaming_processor.py` asynchronously streams gzipped index files. Create a
+YAML configuration similar to `config_template.yaml` and run:
+
+```bash
+python streaming_processor.py config_template.yaml
+```
+
+The processor logs progress and retries with exponential backoff on HTTP 503
+responses.
+
+
+
 
 ### Local crawler
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,28 @@
+"""Configuration loading for the streaming processor."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import yaml
+
+
+@dataclass
+class Config:
+    urls: List[str] = field(default_factory=list)
+    max_concurrent_tasks: int = 10
+    max_retries: int = 4
+    timeout: int = 10
+    record_limit: int = 1000
+
+
+def load_config(path: str) -> Config:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return Config(
+        urls=data.get("urls", []),
+        max_concurrent_tasks=int(data.get("max_concurrent_tasks", 10)),
+        max_retries=int(data.get("max_retries", 4)),
+        timeout=int(data.get("timeout", 10)),
+        record_limit=int(data.get("record_limit", 1000)),
+    )

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -1,0 +1,8 @@
+# Example configuration for streaming_processor.py
+urls:
+  - "https://data.commoncrawl.org/crawl-data/CC-MAIN-2024-10/indexes/cdx-00000.gz"
+max_concurrent_tasks: 10
+max_retries: 4
+timeout: 10
+record_limit: 1000
+

--- a/http_utils.py
+++ b/http_utils.py
@@ -1,0 +1,43 @@
+"""HTTP helpers with exponential backoff."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import AsyncIterator
+
+from aiohttp import ClientResponse, ClientSession, ClientTimeout
+import aiohttp
+
+BACKOFF_DELAYS = [30, 120, 600, 1800]
+logger = logging.getLogger(__name__)
+
+
+async def open_url(session: ClientSession, url: str, timeout: int) -> ClientResponse:
+    """Open ``url`` and return the response object."""
+    return await session.get(url, timeout=ClientTimeout(total=timeout))
+
+
+async def fetch_with_backoff(
+    session: ClientSession, url: str, max_retries: int, timeout: int
+) -> AsyncIterator[ClientResponse]:
+    retries = 0
+    backoff_idx = 0
+    while True:
+        try:
+            resp = await open_url(session, url, timeout)
+            if resp.status == 503:
+                raise aiohttp.ClientResponseError(
+                    resp.request_info, resp.history, status=resp.status
+                )
+            resp.raise_for_status()
+            yield resp
+            return
+        except Exception as exc:  # noqa: BLE001
+            if retries >= max_retries:
+                logger.error("Giving up on %s: %s", url, exc)
+                raise
+            delay = BACKOFF_DELAYS[min(backoff_idx, len(BACKOFF_DELAYS) - 1)]
+            logger.warning("Retry %s for %s in %ss", retries + 1, url, delay)
+            await asyncio.sleep(delay)
+            retries += 1
+            backoff_idx += 1

--- a/json_utils.py
+++ b/json_utils.py
@@ -1,0 +1,30 @@
+"""Utilities for parsing JSON lines with simple repair logic."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import orjson
+
+logger = logging.getLogger(__name__)
+
+
+def parse_json_line(line: str) -> Optional[dict[str, Any]]:
+    """Parse a JSON object from ``line`` with basic error recovery."""
+    try:
+        start = line.index("{")
+    except ValueError:
+        return None
+
+    js = line[start:].strip()
+    try:
+        return orjson.loads(js)
+    except orjson.JSONDecodeError:
+        close = js.rfind("}")
+        if close != -1:
+            try:
+                return orjson.loads(js[: close + 1])
+            except orjson.JSONDecodeError:
+                pass
+        logger.debug("Failed to parse JSON line: %s", line)
+        return None

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,6 @@ python-dotenv
 requests
 
 colorama
+aiohttp
+orjson
+PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ requests==2.32.4
 tqdm==4.67.1
 python-dotenv==1.1.0
 colorama==0.4.6
+
+aiohttp==3.12.13
+orjson==3.10.18
+PyYAML==6.0.2

--- a/sample_output.txt
+++ b/sample_output.txt
@@ -1,0 +1,3 @@
+URL: http://example.com/test.mp4 TS:20250101000000
+URL: http://example.com/test2.mp4 TS:20250101000001
+...

--- a/streaming_processor.py
+++ b/streaming_processor.py
@@ -1,0 +1,146 @@
+# Streaming processor for Common Crawl index files
+from __future__ import annotations
+
+import asyncio
+import os
+import logging
+from typing import AsyncIterator, Iterable, Optional
+
+from aiohttp import ClientSession, ClientTimeout
+import aiohttp
+import aiofiles
+import zlib
+
+from config import Config, load_config
+from json_utils import parse_json_line
+from http_utils import BACKOFF_DELAYS
+
+
+logger = logging.getLogger(__name__)
+
+
+async def _iter_gzip_lines_from_response(resp: aiohttp.ClientResponse) -> AsyncIterator[str]:
+    """Yield decoded lines from a gzip-compressed HTTP response."""
+    decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    buf = b""
+    async for chunk in resp.content.iter_chunked(16384):
+        part = decompressor.decompress(chunk)
+        if part:
+            buf += part
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                yield line.decode("utf-8")
+    buf += decompressor.flush()
+    if buf:
+        yield buf.decode("utf-8")
+
+
+async def _iter_gzip_lines_from_file(path: str) -> AsyncIterator[str]:
+    """Yield lines from a local gzip compressed file."""
+    async with aiofiles.open(path, "rb") as fh:
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        buf = b""
+        while True:
+            chunk = await fh.read(16384)
+            if not chunk:
+                break
+            part = decompressor.decompress(chunk)
+            if part:
+                buf += part
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    yield line.decode("utf-8")
+        buf += decompressor.flush()
+        if buf:
+            yield buf.decode("utf-8")
+
+
+async def fetch_lines(session: ClientSession, url: str, config: Config) -> AsyncIterator[str]:
+    """Fetch ``url`` and yield decompressed lines with retry and backoff."""
+    if os.path.exists(url):
+        async for line in _iter_gzip_lines_from_file(url):
+            yield line
+        return
+
+    retries = 0
+    backoff_idx = 0
+    while True:
+        try:
+            async with session.get(url) as resp:
+                if resp.status == 503:
+                    raise aiohttp.ClientResponseError(
+                        resp.request_info, resp.history, status=resp.status
+                    )
+                resp.raise_for_status()
+                async for line in _iter_gzip_lines_from_response(resp):
+                    yield line
+                return
+        except Exception as exc:  # noqa: BLE001
+            if retries >= config.max_retries:
+                logger.error("Failed to fetch %s: %s", url, exc)
+                raise
+            delay = BACKOFF_DELAYS[min(backoff_idx, len(BACKOFF_DELAYS) - 1)]
+            logger.warning("Retry %s for %s in %ss", retries + 1, url, delay)
+            await asyncio.sleep(delay)
+            retries += 1
+            backoff_idx += 1
+
+
+async def producer(queue: asyncio.Queue[str], urls: Iterable[str]) -> None:
+    for url in urls:
+        await queue.put(url)
+    await queue.put(None)  # sentinel
+
+
+async def consumer(queue: asyncio.Queue[Optional[str]], session: ClientSession, config: Config) -> None:
+    while True:
+        url = await queue.get()
+        if url is None:
+            queue.task_done()
+            break
+        logger.info("Processing %s", url)
+        count = 0
+        try:
+            async for line in fetch_lines(session, url, config):
+                record = parse_json_line(line)
+                if not record:
+                    continue
+                logger.info(
+                    "URL: %s TS:%s", record.get("url"), record.get("timestamp")
+                )
+                count += 1
+                if count >= config.record_limit:
+                    logger.info("Record limit reached for %s", url)
+                    break
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed processing %s: %s", url, exc)
+        finally:
+            queue.task_done()
+
+
+async def run(config: Config) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    queue: asyncio.Queue[Optional[str]] = asyncio.Queue()
+    async with ClientSession(timeout=ClientTimeout(total=config.timeout)) as session:
+        cons = [asyncio.create_task(consumer(queue, session, config)) for _ in range(config.max_concurrent_tasks)]
+        await producer(queue, config.urls)
+        await queue.join()
+        for _ in cons:
+            await queue.put(None)
+        await queue.join()
+        for c in cons:
+            await c
+
+
+def main(config_path: str) -> None:
+    config = load_config(config_path)
+    asyncio.run(run(config))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python streaming_processor.py config.yaml")
+        raise SystemExit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- implement `streaming_processor.py` for async processing of gzip index files
- add JSON repair and HTTP backoff utilities
- add configuration loader with YAML support
- provide example config and sample output
- document new tool in README
- include aiohttp/orjson/PyYAML in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ea179575c8322903b7e26cecd398b