### PR TITLE
Handle 404 errors in streaming processor

### DIFF
--- a/config_template.yaml
+++ b/config_template.yaml
@@ -1,6 +1,7 @@
 # Example configuration for streaming_processor.py
 urls:
-  - "https://data.commoncrawl.org/crawl-data/CC-MAIN-2024-10/indexes/cdx-00000.gz"
+  # Update to a known crawl so the example works out of the box
+  - "https://data.commoncrawl.org/crawl-data/CC-MAIN-2023-06/indexes/cdx-00000.gz"
 max_concurrent_tasks: 10
 max_retries: 4
 timeout: 10

--- a/streaming_processor.py
+++ b/streaming_processor.py
@@ -71,6 +71,9 @@ async def fetch_lines(
     while True:
         try:
             async with session.get(url) as resp:
+                if resp.status == 404:
+                    logger.error("URL not found: %s", url)
+                    return
                 if resp.status == 503:
                     raise aiohttp.ClientResponseError(
                         resp.request_info, resp.history, status=resp.status


### PR DESCRIPTION
## Summary
- avoid retries for missing index files (HTTP 404) in `streaming_processor.py`
- update the example configuration to use a valid crawl

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebc0944688322b07ac8a0b707695a